### PR TITLE
fix(ArgoCD): missing k8s secret for argocd-repo-server

### DIFF
--- a/argocd/kustomization.yaml
+++ b/argocd/kustomization.yaml
@@ -12,3 +12,6 @@ resources:
 
 patches:
   - path: argocd-repo-server-ksops-patch.yaml
+
+generators:
+  - ./secret-generator.yaml

--- a/argocd/secret-generator.yaml
+++ b/argocd/secret-generator.yaml
@@ -1,0 +1,11 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: default-secret-generator
+  kind: ksops
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - ./sops-age-secret.enc.yaml


### PR DESCRIPTION
# PR (Pull Request) on #1

## What?

`argocd-repo-servrer` pod's init container status not `RUNNINH`

* **Issue:** #2 

## Why?

Missing `sops-age` secret

## How?

After installing ArgoCD CRDs, user evaluated the following

`make deploy_services` 

### Add

- Kustomization secret-generator to source the encrypted `sops-age-secret`

### Change

- N/A

### Remove

- N/A

## Testing

```shell-session
$ k -n argocd get pods
NAME                                                READY   STATUS    RESTARTS   AGE
argocd-application-controller-0                     1/1     Running   0          99m
argocd-applicationset-controller-8485455fd5-plqxk   1/1     Running   0          99m
argocd-dex-server-66779d96df-8snzc                  1/1     Running   0          99m
argocd-notifications-controller-c4b69fb67-rtlks     1/1     Running   0          99m
argocd-redis-7bf7cb9748-n5cjc                       1/1     Running   0          99m
argocd-repo-server-57d8bff79d-dlhm4                 1/1     Running   0          12m
argocd-server-544b7f897d-7xpnf                      1/1     Running   0          99m
```


## Anything else?

N/A

[//]:# (https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)
