### PR TITLE
fix(Makefile): `argocd_install` rule to bypass namespace already exists

### DIFF
--- a/argocd/Makefile
+++ b/argocd/Makefile
@@ -8,7 +8,7 @@ git_remote := $(shell git remote --verbose | head -n 1 | cut -d ' ' -f 1 | awk '
 export
 
 argocd_install: ## Install ArgoCD (Getting Started)
-	kubectl create namespace argocd
+	@kubectl create namespace argocd || true
 	kubectl apply --namespace argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 
 argocd_login_cli: ## Login to Local ArgoCD with the CLI


### PR DESCRIPTION
# PR (Pull Request) on #0

## What?

<!-- markdownlint-disable-file MD004 -->
* **Issue:** #0

## Why?
When ArgoCD namespace already exists then the Makefule rule `argocd_install` fails to continue to install CRDs

## How?

`make argocd_install`

### Add

- N/A

### Change

- Utilise `@` and `|| true`

### Remove

- N/A

## Testing

```shell-session
$ make argocd_install                     
Error from server (AlreadyExists): namespaces "argocd" already exists
kubectl apply --namespace argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
customresourcedefinition.apiextensions.k8s.io/applications.argoproj.io unchanged
...
```

## Anything else?

N/A

[//]:# (https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)
