### PR TITLE
fix(Kustomization/images): correct `images` name

### DIFF
--- a/elixir/overlays/dev/kustomization.yaml
+++ b/elixir/overlays/dev/kustomization.yaml
@@ -20,6 +20,6 @@ transformers:
 namePrefix: jpat-dev-
 namespace: kans-elixir-dev
 images:
-  - name: app
+  - name: kaap
     newName: elixir-dev
     newTag: 0.1.0


### PR DESCRIPTION
# PR (Pull Request) on #0

## What?

When  run customise build with kubectl diff/apply the intended newName/newTag for the target image are not set.  

<!-- markdownlint-disable-file MD004 -->
* **Issue:** #0

## Why?
The source name of the image is incorrect

## How?

when newName: and newTag is different than the base these newName and newTag values in the overlays/dev kustomization file are not applied.
### Add

- N/A

### Change

- images: name=kaap

### Remove

- N/A

## Testing

```shell-session
$ kustomize build --enable-alpha-plugins --enable-exec . | kubectl diff --filename -                                       

metadata.generation  (apps/v1/Deployment/kans-elixir-dev/jpat-dev-kans)
  ± value change
    - 3
    + 4

spec.template.spec.containers.this.image  (apps/v1/Deployment/kans-elixir-dev/jpat-dev-kans)
  ± value change
    - kaap:0.1.0
    + elixir-dev:0.2.0
```

## Anything else?

N/A

[//]:# (https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)
